### PR TITLE
RFR - fixing continuous deployment

### DIFF
--- a/.github/workflows/makefile_ci.yml
+++ b/.github/workflows/makefile_ci.yml
@@ -107,4 +107,4 @@ jobs:
           SSH_HOST: ${{ secrets.AWS_SSH_HOST }}
 
       - name: Deploy
-        run: ssh aws 'cd ~/kamon && git pull && docker-compose stop && docker-compose build && docker-compose up -d'
+        run: ssh aws 'cd ~/kamon && git pull && docker-compose stop && docker-compose build && docker-compose up -d && docker builder prune'


### PR DESCRIPTION
Docker building process was leaving a lot of artifacts and quickly took all space on our EC2 instance.
This should alleviate it by cleaning everything after build.